### PR TITLE
Fix bug: CRC checksum of IDAT chunk was wrong under some circumstances.

### DIFF
--- a/ext/apple_png/apple_png.c
+++ b/ext/apple_png/apple_png.c
@@ -318,7 +318,7 @@ static int readPngChunks(VALUE self, const char *oldPNG, size_t oldPngLength, dy
             chunkData = (char*)standardPngCompressedPixelData;
             chunkCRC = png_crc32(chunkType, chunkData, chunkLength);
             tmp_chunkCRC = htonl(chunkCRC);
-            chunkCRC_raw = (char *)(&tmp_chunkCRC);
+            memcpy((void*)chunkCRC_raw, &tmp_chunkCRC, 4);
 
             /* we're done */
             breakLoop = 1;


### PR DESCRIPTION
Don't try to access CRC chunk in memory that is already freed, but copy it to where
we can still access it later.
